### PR TITLE
Browser Console Logging and Selenium Grid Node Ip retrieval

### DIFF
--- a/TestHtml/javascript/console.js
+++ b/TestHtml/javascript/console.js
@@ -1,0 +1,11 @@
+function triggerInfo() {
+    console.info("console.info: triggerInfo() executed")
+}
+
+function triggerWarn() {
+    console.warn("console.warn: triggerWarn() executed")
+}
+
+function triggerError() {
+    console.error("console.error: triggerError() executed")
+}

--- a/TestHtml/testpage.html
+++ b/TestHtml/testpage.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="javascript/console.js"></script>
     <title>Web-Test-Framework: Test HTML Page</title>
 </head>
 
@@ -163,7 +164,7 @@
                 <div data-toggle="collapse" data-target="#modalDivContainer"><button type="button" id="modal-btn" class="btn btn-default btn-lg btn-block">test-modal</button></div>
                 <div id="modalDivContainer" class="collapse">
                     <!-- Trigger the modal with a button -->
-                    <button type="button" class="btn btn-info btn-lg center-block" data-toggle="modal" data-target="#testModal">Open Modal</button>
+                    <button type="button" class="btn btn-primary btn-lg center-block" data-toggle="modal" data-target="#testModal">Open Modal</button>
 
                     <!-- Modal -->
                     <div class="modal fade" id="testModal" role="dialog">
@@ -213,6 +214,22 @@
                         <div id="menu4" class="tab-pane fade">
                             <h3>Menu 4</h3>
                             <p>Menu 4 Paragraph Text</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="test-browser-console">
+                <div data-toggle="collapse" data-target="#browserConsoleDivContainer"><button type="button" id="browser-console-btn" class="btn btn-default btn-lg btn-block">test-browser-console</button></div>
+                <div id="browserConsoleDivContainer" class="collapse">
+                    <div class="btn-group btn-group-justified">
+                        <div class="btn-group btn-group-lg">
+                            <button type="button" id="consoleInfoBtnId" class="btn btn-info" onclick="triggerInfo()">Console Info</button>
+                        </div>
+                        <div class="btn-group btn-group-lg">
+                            <button type="button" id="consoleWarnBtnId" class="btn btn-warning" onclick="triggerWarn()">Console Warn</button>
+                        </div>
+                        <div class="btn-group btn-group-lg">
+                            <button type="button" id="consoleErrorBtnId" class="btn btn-danger" onclick="triggerError()">Console Error</button>
                         </div>
                     </div>
                 </div>

--- a/dotnet/WebTestFramework/Framework/Browser/BaseBrowser.cs
+++ b/dotnet/WebTestFramework/Framework/Browser/BaseBrowser.cs
@@ -1,20 +1,59 @@
-﻿using OpenQA.Selenium;
+﻿using Newtonsoft.Json.Linq;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.UI;
+using RestSharp;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 
 namespace Framework.Browser
 {
     public class BaseBrowser
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private string _sessionId;
+        private RestClient _client;
+
         public IWebDriver Driver { get; set; }
         public WebDriverWait DriverWait { get; set; }
+        public List<LogEntry> Logs => Driver.GetBrowserLogs().ToList();
 
         public BaseBrowser(IWebDriver driver)
         {
+            _client = new RestClient();
             Driver = driver;
             Driver.Manage().Timeouts().ImplicitlyWait(TimeSpan.FromSeconds(WebDriverSettings.ImplicitWait));
             DriverWait = new WebDriverWait(driver, TimeSpan.FromSeconds(WebDriverSettings.ExplicitWait));
+
+            _sessionId = ((RemoteWebDriver)Driver).SessionId != null ? ((RemoteWebDriver)Driver).SessionId.ToString() : string.Empty;
+        }
+
+        public string GetNodeIp()
+        {
+            if (string.IsNullOrEmpty(_sessionId))
+            {
+                return string.Empty;
+            }
+            
+            _client.BaseUrl = new Uri(WebDriverSettings.SeleniumGridServer);
+            var request = new RestRequest(Method.GET);
+            request.Resource = "grid/api/testsession";
+            request.AddQueryParameter("session", _sessionId);
+
+            IRestResponse response = _client.Execute(request);
+
+            if (!response.StatusCode.Equals(HttpStatusCode.OK))
+            {
+                var msg = $"Failed to get testsession data for session={_sessionId}";
+                Log.Error(msg);
+                throw new Exception(msg);
+            }
+
+            var nodeIp = JObject.Parse(response.Content).GetValue("proxyId").ToString();
+            return new Uri(nodeIp).Host;                
         }
     }
 }

--- a/dotnet/WebTestFramework/Framework/Browser/WebDriverExtensions.cs
+++ b/dotnet/WebTestFramework/Framework/Browser/WebDriverExtensions.cs
@@ -2,6 +2,7 @@
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
 using System;
+using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -288,6 +289,11 @@ namespace Framework.Browser
 
             var screenShotPath = stringBuilder.ToString();
             screenshot.SaveAsFile(screenShotPath, ImageFormat.Jpeg);
+        }
+
+        public static ReadOnlyCollection<LogEntry> GetBrowserLogs(this IWebDriver browser)
+        {
+            return browser.Manage().Logs.GetLog(LogType.Browser);
         }
     }
 }

--- a/dotnet/WebTestFramework/Framework/Browser/WebDriverFactory.cs
+++ b/dotnet/WebTestFramework/Framework/Browser/WebDriverFactory.cs
@@ -15,70 +15,126 @@ namespace Framework.Browser
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly InternetExplorerOptions IeOptions = new InternetExplorerOptions
-        {
-            IgnoreZoomLevel = true,
-            EnsureCleanSession = true,
-            UnexpectedAlertBehavior = InternetExplorerUnexpectedAlertBehavior.Dismiss,
-            PageLoadStrategy = InternetExplorerPageLoadStrategy.Normal
-        };
+        private readonly ChromeOptions _chromeOpts;
+        private readonly EdgeOptions _edgeOpts;
+        private readonly FirefoxOptions _firefoxOpts;
+        private readonly PhantomJSOptions _phantomJsOpts;
+        private readonly SafariOptions _safariOpts;
+        private readonly InternetExplorerOptions _ieOpts;
 
-        public static IWebDriver GetBrowser(BrowserType browser)
+        private WebDriverFactory()
         {
-            Log.Debug($"EXECUTING: GetBrowser(): {browser}");
+            _chromeOpts = new ChromeOptions();
+            _edgeOpts = new EdgeOptions();
+            _firefoxOpts = new FirefoxOptions();
+            _phantomJsOpts = new PhantomJSOptions();
+            _safariOpts = new SafariOptions();
+            _ieOpts = new InternetExplorerOptions
+            {
+                EnableNativeEvents = false,
+                IgnoreZoomLevel = true,
+                EnsureCleanSession = true,
+                UnexpectedAlertBehavior = InternetExplorerUnexpectedAlertBehavior.Dismiss,
+                PageLoadStrategy = InternetExplorerPageLoadStrategy.Normal
+            };           
+        }
+
+        private void AssignBrowserLogLevel(LogLevel logLevel)
+        {
+            _chromeOpts.SetLoggingPreference(LogType.Browser, logLevel);
+            _edgeOpts.SetLoggingPreference(LogType.Browser, logLevel);
+            _firefoxOpts.SetLoggingPreference(LogType.Browser, logLevel);
+            _ieOpts.SetLoggingPreference(LogType.Browser, logLevel);
+            _phantomJsOpts.SetLoggingPreference(LogType.Browser, logLevel);
+            _safariOpts.SetLoggingPreference(LogType.Browser, logLevel);
+        }
+
+        public static WebDriverFactory Factory()
+        {
+            return new WebDriverFactory();
+        }
+
+        public IWebDriver GetBrowser(BrowserType browser, LogLevel logLevel = LogLevel.Severe)
+        {
+            if (!string.IsNullOrEmpty(WebDriverSettings.SeleniumGridServer))
+            {
+                Log.Debug("Selenium Grid Server is specified in app.config, will attempt to retrieve Browser from Grid...");
+                return GetRemoteBrowser(browser, WebDriverSettings.BrowserVersion, logLevel);
+            }
+                
+            Log.Debug($"EXECUTING: GetBrowser(): {browser},{logLevel}");
             var driverPath = Path.GetDirectoryName(new Uri(typeof(WebDriverFactory).Assembly.CodeBase).LocalPath);
             Log.Debug($"Path to Driver binaries: {driverPath}");
+
+            AssignBrowserLogLevel(logLevel);
 
             switch (browser)
             {
                 case BrowserType.Chrome:
-                    return new ChromeDriver(driverPath);
-                case BrowserType.Edge:
-                    return new EdgeDriver(driverPath);
-                case BrowserType.Firefox:
-                    return new FirefoxDriver();
-                case BrowserType.IE:
-                    return new InternetExplorerDriver(driverPath, IeOptions);
-                case BrowserType.Phantomjs:
-                    return new PhantomJSDriver(driverPath);
-                case BrowserType.Safari:
-                    return new SafariDriver(driverPath);
+                    return new ChromeDriver(driverPath, _chromeOpts);
+                case BrowserType.Edge:                 
+                    return new EdgeDriver(driverPath, _edgeOpts);
+                case BrowserType.Firefox:                   
+                    return new FirefoxDriver(_firefoxOpts);
+                case BrowserType.IE:                  
+                    return new InternetExplorerDriver(driverPath, _ieOpts);
+                case BrowserType.Phantomjs:                   
+                    return new PhantomJSDriver(driverPath, _phantomJsOpts);
+                case BrowserType.Safari:                   
+                    return new SafariDriver(driverPath, _safariOpts);
                 default:
                     throw new Exception($"Unsupported BrowserType={browser}");
             }
         }
 
-        public static IWebDriver GetRemoteBrowser(Uri gridAddress, BrowserType browser, string version = null)
+        private IWebDriver GetRemoteBrowser(BrowserType browser, string version = null, LogLevel logLevel = LogLevel.Severe)
         {
+            var gridAddress = new Uri($"{WebDriverSettings.SeleniumGridServer}/wd/hub");
             Log.Debug($"EXECUTING: GetRemoteBrowser(): {gridAddress.AbsoluteUri},{browser},{(!string.IsNullOrEmpty(version) ? version : string.Empty)}");
             ICapabilities capabillities;
+
+            AssignBrowserLogLevel(logLevel);
 
             switch (browser)
             {
                 case BrowserType.Chrome:
-                    capabillities = DesiredCapabilities.Chrome();
+                    capabillities = _chromeOpts.ToCapabilities();
                     break;
                 case BrowserType.Edge:
-                    capabillities = DesiredCapabilities.Edge();
+                    capabillities = _edgeOpts.ToCapabilities();
                     break;
                 case BrowserType.Firefox:
-                    capabillities = DesiredCapabilities.Firefox();
+                    capabillities = _firefoxOpts.ToCapabilities();
                     break;
                 case BrowserType.IE:
-                    IeOptions.AddAdditionalCapability("version", !string.IsNullOrEmpty(version) ? version : "11");
-                    capabillities = IeOptions.ToCapabilities();
+                    _ieOpts.AddAdditionalCapability("version", !string.IsNullOrEmpty(version) ? version : "11");
+                    capabillities = _ieOpts.ToCapabilities();
                     break;
                 case BrowserType.Phantomjs:
-                    capabillities = DesiredCapabilities.PhantomJS();
+                    capabillities = _phantomJsOpts.ToCapabilities();
                     break;
                 case BrowserType.Safari:
-                    capabillities = DesiredCapabilities.Safari();
+                    capabillities = _safariOpts.ToCapabilities();
                     break;
                 default:
                     throw new Exception($"Unsupported BrowserType={browser}");                    
             }
 
-            return new RemoteWebDriver(gridAddress, capabillities);
+            try
+            {
+                return new RemoteWebDriver(gridAddress, capabillities);
+            }
+
+            catch (Exception e)
+            {
+                if (e is WebDriverTimeoutException || e is WebDriverException)
+                {
+                    var msg = $"Unable to connect to Selenium Grid: {gridAddress}, {e.Message}";
+                    throw new Exception(msg, e);
+                }
+
+                throw new Exception($"An exception has occurred: {e.Message}", e);
+            }            
         }
     }
 }

--- a/dotnet/WebTestFramework/Framework/Browser/WebDriverSettings.cs
+++ b/dotnet/WebTestFramework/Framework/Browser/WebDriverSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using OpenQA.Selenium;
+using System.Configuration;
 
 namespace Framework.Browser
 {
@@ -7,6 +8,8 @@ namespace Framework.Browser
         public static string SeleniumGridServer => ConfigurationManager.AppSettings["SeleniumGridServer"];
         public static int ImplicitWait => int.Parse(ConfigurationManager.AppSettings["ImplicitWait"]);
         public static int ExplicitWait => int.Parse(ConfigurationManager.AppSettings["ExplicitWait"]);
+        public static LogLevel BrowserLogLevel => GetLogLevel(int.Parse(ConfigurationManager.AppSettings["BrowserLogLevel"]));
+        public static string BrowserVersion => ConfigurationManager.AppSettings["BrowserVersion"];
         public static string OutlineColor => ConfigurationManager.AppSettings["OutlineColor"];
         public static bool ApplyOutline => GetBoolValue("ApplyOutline");
 
@@ -18,6 +21,11 @@ namespace Framework.Browser
                 result = defaultValue;
             }
             return result;
+        }
+
+        private static LogLevel GetLogLevel(int logValue)
+        {
+            return (LogLevel)logValue;
         }
     }
 }

--- a/dotnet/WebTestFramework/Framework/Elements/Button.cs
+++ b/dotnet/WebTestFramework/Framework/Elements/Button.cs
@@ -1,0 +1,9 @@
+﻿using OpenQA.Selenium;
+
+namespace Framework.Elements
+{
+    public class Button : PageLink
+    {
+        public Button(ISearchContext context, By selector) : base(context, selector) { }
+    }
+}

--- a/dotnet/WebTestFramework/Framework/Framework.csproj
+++ b/dotnet/WebTestFramework/Framework/Framework.csproj
@@ -36,8 +36,16 @@
       <HintPath>..\packages\log4net.2.0.7\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net452\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -66,6 +74,7 @@
     <Compile Include="Browser\WebDriverFactory.cs" />
     <Compile Include="Browser\WebDriverSettings.cs" />
     <Compile Include="Constants\DocumentReadyState.cs" />
+    <Compile Include="Elements\Button.cs" />
     <Compile Include="Elements\WebElementExtensions.cs" />
     <Compile Include="Elements\BaseElement.cs" />
     <Compile Include="Elements\Image.cs" />
@@ -83,6 +92,8 @@
     <Compile Include="PageObjects\BasePage.cs" />
     <Compile Include="PageObjects\BaseTable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\Browser\BrowserConsoleTests.cs" />
+    <Compile Include="UnitTests\Browser\ScreenshotTests.cs" />
     <Compile Include="UnitTests\PageObjects\BasePageTests.cs" />
     <Compile Include="UnitTests\Elements\ImageTests.cs" />
     <Compile Include="UnitTests\PageObjects\NavigationMenuTests.cs" />
@@ -99,7 +110,7 @@
     <Compile Include="UnitTests\Elements\TextFieldTests.cs" />
     <Compile Include="UnitTests\Elements\TextInputTests.cs" />
     <Compile Include="UnitTests\Elements\ToggleInputTests.cs" />
-    <Compile Include="UnitTests\WebDriverExtensionsTests.cs" />
+    <Compile Include="UnitTests\Browser\WebDriverExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="app.config">

--- a/dotnet/WebTestFramework/Framework/PageObjects/BasePage.cs
+++ b/dotnet/WebTestFramework/Framework/PageObjects/BasePage.cs
@@ -1,7 +1,10 @@
-﻿using Framework.Constants;
+﻿using Framework.Browser;
+using Framework.Constants;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Framework.PageObjects
 {
@@ -9,10 +12,11 @@ namespace Framework.PageObjects
     {
         protected static readonly log4net.ILog Log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public IWebDriver Browser { get; set; }
-        public WebDriverWait BrowserWait { get; set; }
-        public string Title { get; set; }
-        public string Url { get; set; }
+        public IWebDriver Browser { get; private set; }
+        public WebDriverWait BrowserWait { get; private set; }
+        public string Title { get; private set; }
+        public string Url { get; private set; }
+        public List<LogEntry> BrowserLogs { get; private set; }
 
         protected BasePage(IWebDriver driver)
         {
@@ -29,6 +33,8 @@ namespace Framework.PageObjects
             }
 
             Log.Info($"{GetType().Name} has loaded successfully");
+
+            BrowserLogs = Browser.GetBrowserLogs().ToList();
         }
 
         public virtual bool IsLoaded()

--- a/dotnet/WebTestFramework/Framework/UnitTests/Browser/BrowserConsoleTests.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/Browser/BrowserConsoleTests.cs
@@ -1,0 +1,96 @@
+﻿using Framework.Browser;
+using Framework.UnitTests.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using System.Linq;
+
+namespace Framework.UnitTests.Browser
+{
+    [TestFixture]
+    [Parallelizable]
+    public class BrowserConsoleTests : TestBase
+    {
+        [OneTimeSetUp]
+        public override void SetupBrowser()
+        {
+            Log.Info($"START: {TestContext.CurrentContext.Test.ClassName}");
+        }
+
+        [SetUp]
+        public override void TestStart()
+        {
+            Log.Info($"START: {TestContext.CurrentContext.Test.Name}");
+        }
+
+        [TearDown]
+        public override void TestFinish()
+        {
+            Log.Info($"FINISH: {TestContext.CurrentContext.Test.Name}: {TestContext.CurrentContext.Result.Outcome.Status}");
+            Browser.Driver.Quit();
+        }
+
+        [OneTimeTearDown]
+        public override void CloseBrowser()
+        {
+            Log.Info($"EXECUTING: CloseBrowser()");
+            var passCnt = $"PASSED={TestContext.CurrentContext.Result.PassCount}";
+            var failCnt = $"FAILED={TestContext.CurrentContext.Result.FailCount}";
+            var inconclusiveCnt = $"INCONCLUSIVE={TestContext.CurrentContext.Result.InconclusiveCount}";
+            var skippedCnt = $"SKIPPED={TestContext.CurrentContext.Result.SkipCount}";
+            var warningCnt = $"WARNING={TestContext.CurrentContext.Result.WarningCount}";
+
+            Log.Info($"FINISH: {TestContext.CurrentContext.Test.ClassName}: {passCnt},{failCnt},{inconclusiveCnt},{skippedCnt},{warningCnt}");
+        }
+
+
+        private void SetupBrowserWithLoggingLevel(LogLevel level)
+        {
+            Browser = new BaseBrowser(WebDriverFactory.Factory().GetBrowser(BrowserType.Chrome, logLevel: level));
+            Browser.Driver.Navigate().GoToUrl($"{GetTestHtmlFolderPath()}/TestHtml/testpage.html");
+            Log.Info($"Browser URL={Browser.Driver.Url}");
+            page = new TestHtmlPage(Browser.Driver);
+        }
+
+        [Test]
+        public void InfoTest()
+        {
+            SetupBrowserWithLoggingLevel(LogLevel.Info);
+            page.ExpandDiv(DivSection.TestBrowserConsole, true);
+            page.ConsoleInfoButton.Click();
+            
+            var infoLogs = Browser.Logs;
+
+            Assert.That(infoLogs.Any, Is.True);
+            Assert.That(infoLogs.Count, Is.EqualTo(1));
+            Assert.That(infoLogs.First().Message, Does.Contain("console.info: triggerInfo() executed"));
+        }
+
+        [Test]
+        public void WarnTest()
+        {
+            SetupBrowserWithLoggingLevel(LogLevel.Warning);
+            page.ExpandDiv(DivSection.TestBrowserConsole, true);
+            page.ConsoleWarnButton.Click();
+
+            var warnLogs = Browser.Logs;
+
+            Assert.That(warnLogs.Any, Is.True);
+            Assert.That(warnLogs.Count, Is.EqualTo(1));
+            Assert.That(warnLogs.First().Message, Does.Contain("console.warn: triggerWarn() executed"));
+        }
+
+        [Test]
+        public void ErrorTest()
+        {
+            SetupBrowserWithLoggingLevel(LogLevel.Severe);
+            page.ExpandDiv(DivSection.TestBrowserConsole, true);
+            page.ConsoleErrorButton.Click();
+
+            var errorLogs = Browser.Logs;
+
+            Assert.That(errorLogs.Any, Is.True);
+            Assert.That(errorLogs.Count, Is.EqualTo(1));
+            Assert.That(errorLogs.First().Message, Does.Contain("console.error: triggerError() executed"));
+        }
+    }
+}

--- a/dotnet/WebTestFramework/Framework/UnitTests/Browser/ScreenshotTests.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/Browser/ScreenshotTests.cs
@@ -1,0 +1,22 @@
+﻿using Framework.Browser;
+using NUnit.Framework;
+using System;
+using System.IO;
+namespace Framework.UnitTests.Browser
+{
+    [TestFixture]
+    [Parallelizable]
+    public class ScreenshotTests : TestBase
+    {
+        [Test]
+        public void TakeScreenshotTest()
+        {
+            var fileName = $"{TestContext.CurrentContext.Test.Name}.jpg";
+            Browser.Driver.TakeScreenshot(fileName);
+
+            var screenshotFile = Path.GetFileName(new Uri(typeof(WebDriverExtensions).Assembly.CodeBase).LocalPath + @"\Screenshots\" + fileName);
+
+            Assert.That(screenshotFile, Is.EqualTo(fileName));
+        }
+    }
+}

--- a/dotnet/WebTestFramework/Framework/UnitTests/Browser/WebDriverExtensionsTests.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/Browser/WebDriverExtensionsTests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using System;
 
-namespace Framework.UnitTests
+namespace Framework.UnitTests.Browser
 {
     [TestFixture]
     [Parallelizable]

--- a/dotnet/WebTestFramework/Framework/UnitTests/PageObjects/DivSection.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/PageObjects/DivSection.cs
@@ -11,6 +11,7 @@
         TestImage,
         TestTable,
         TestModal,
-        TestTabMenuNav
+        TestTabMenuNav,
+        TestBrowserConsole
     }
 }

--- a/dotnet/WebTestFramework/Framework/UnitTests/PageObjects/TestHtmlpage.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/PageObjects/TestHtmlpage.cs
@@ -20,6 +20,7 @@ namespace Framework.UnitTests.PageObjects
         private readonly By _tableDivButton = By.Id("table-btn");
         private readonly By _modalDivButton = By.Id("modal-btn");
         private readonly By _tabMenuDivButton = By.Id("tab-menu-btn");
+        private readonly By _browserConsoleDivButton = By.Id("browser-console-btn");
 
         //Collapsable Divs Locators
         private readonly By _navMenuDiv = By.Id("navDivId");
@@ -32,7 +33,7 @@ namespace Framework.UnitTests.PageObjects
         private readonly By _tableDiv = By.Id("tableDivContainer");
         private readonly By _modalDiv = By.Id("modalDivContainer");
         private readonly By _tabMenuDiv = By.Id("tabmenuNavDivContainer");
-
+        private readonly By _browserConsoleDiv = By.Id("browserConsoleDivContainer");
 
         //Elements
         public TextField TextField => new TextField(Browser, By.Id("textId"));
@@ -47,6 +48,9 @@ namespace Framework.UnitTests.PageObjects
         public Image Image => new Image(Browser, By.Id("imgId"));
         public PageLink PageLink => new PageLink(Browser, By.Id("textLinkId"));
         public Image ImageLink => new Image(Browser, By.Id("imgLinkId"));
+        public Button ConsoleInfoButton => new Button(Browser, By.Id("consoleInfoBtnId"));
+        public Button ConsoleWarnButton => new Button(Browser, By.Id("consoleWarnBtnId"));
+        public Button ConsoleErrorButton => new Button(Browser, By.Id("consoleErrorBtnId"));
 
         public TestHtmlPage(IWebDriver browser) : base(browser) { }
 
@@ -98,6 +102,10 @@ namespace Framework.UnitTests.PageObjects
                 case DivSection.TestTabMenuNav:
                     button = Browser.FindElement(_tabMenuDivButton);
                     div = Browser.FindElement(_tabMenuDiv);
+                    break;
+                case DivSection.TestBrowserConsole:
+                    button = Browser.FindElement(_browserConsoleDivButton);
+                    div = Browser.FindElement(_browserConsoleDiv);
                     break;
                 default:
                     var msg = $"{GetType().Name}: Unsupported DivSection={section} used for ExpandDiv";

--- a/dotnet/WebTestFramework/Framework/UnitTests/TestBase.cs
+++ b/dotnet/WebTestFramework/Framework/UnitTests/TestBase.cs
@@ -21,30 +21,30 @@ namespace Framework.UnitTests
         }
 
         [OneTimeSetUp]
-        public void SetupBrowser()
+        public virtual void SetupBrowser()
         {
             Log.Info($"START: {TestContext.CurrentContext.Test.ClassName}");
             Log.Info($"EXECUTING: SetupBrowser(): {BrowserType.Chrome}");
-            Browser = new BaseBrowser(WebDriverFactory.GetBrowser(BrowserType.Chrome));
+            Browser = new BaseBrowser(WebDriverFactory.Factory().GetBrowser(BrowserType.Chrome, logLevel: WebDriverSettings.BrowserLogLevel));
             Browser.Driver.Navigate().GoToUrl($"{GetTestHtmlFolderPath()}/TestHtml/testpage.html");
             Log.Info($"Browser URL={Browser.Driver.Url}");
             page = new TestHtmlPage(Browser.Driver);
         }
 
         [SetUp]
-        public void LogTestStart()
+        public virtual void TestStart()
         {
             Log.Info($"START: {TestContext.CurrentContext.Test.Name}");
         }
 
         [TearDown]
-        public void LogTestFinish()
+        public virtual void TestFinish()
         {
             Log.Info($"FINISH: {TestContext.CurrentContext.Test.Name}: {TestContext.CurrentContext.Result.Outcome.Status}");
         }
 
         [OneTimeTearDown]
-        public void CloseBrowser()
+        public virtual void CloseBrowser()
         {
             Log.Info($"EXECUTING: CloseBrowser()");
             Browser.Driver.Quit();

--- a/dotnet/WebTestFramework/Framework/app.config
+++ b/dotnet/WebTestFramework/Framework/app.config
@@ -42,9 +42,20 @@
   </log4net>
   
   <appSettings>
+    <!-- SeleniumGridServer: Just need to specify host and port (i.e. http://localhost:4444) -->
     <add key="SeleniumGridServer" value=""/>
+    
+    <!-- Waits: Value in seconds-->
     <add key="ImplicitWait" value="2"/>
     <add key="ExplicitWait" value="5"/>
+    
+    <!-- BrowserLogLevel: 0=All, 1=Debug, 2=Info, 3=Warning, 4=Severe, 5=Off -->
+    <add key="BrowserLogLevel" value="3"/>
+    
+    <!-- BrowserVersion: Mainly used for Internet Explorer-->
+    <add key="BrowserVersion" value="11"/>
+    
+    <!-- Outline: True/False and respective HTML Hex Color Code -->
     <add key="ApplyOutline" value="True"/>
     <add key="OutlineColor" value="#FF0000"/>
   </appSettings>

--- a/dotnet/WebTestFramework/Framework/packages.config
+++ b/dotnet/WebTestFramework/Framework/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.7" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net452" />
   <package id="Selenium.Chrome.WebDriver" version="2.27" targetFramework="net452" />
   <package id="Selenium.Firefox.WebDriver" version="0.13.0" targetFramework="net452" />
   <package id="Selenium.InternetExplorer.WebDriver" version="3.00" targetFramework="net452" />


### PR DESCRIPTION
Browser Console Logs is now available (and you can specify the LogLevel needed)
Able to get the IP of the Selenium Grid Node that the test is currently using for WebDriver instance (when using the Grid)